### PR TITLE
Dagger/HiltからKoinへ移行して、依存性注入時のクラッシュを修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,4 +72,8 @@ dependencies {
     implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
     kapt 'androidx.hilt:hilt-compiler:1.0.0'
 
+    def koin_android_version = "3.4.0"
+    implementation "io.insert-koin:koin-core:$koin_android_version"
+    implementation "io.insert-koin:koin-android:$koin_android_version"
+
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,9 +69,6 @@ dependencies {
     implementation 'androidx.room:room-ktx:2.5.1'
     kapt 'androidx.room:room-compiler:2.5.1'
 
-    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
-    kapt 'androidx.hilt:hilt-compiler:1.0.0'
-
     def koin_android_version = "3.4.0"
     implementation "io.insert-koin:koin-core:$koin_android_version"
     implementation "io.insert-koin:koin-android:$koin_android_version"

--- a/app/src/main/java/com/example/mytodo/MainActivity.kt
+++ b/app/src/main/java/com/example/mytodo/MainActivity.kt
@@ -2,10 +2,18 @@ package com.example.mytodo
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import com.example.mytodo.di.appModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        startKoin {
+            androidContext(this@MainActivity)
+            modules(appModule)
+        }
         setContentView(R.layout.activity_main)
     }
 }

--- a/app/src/main/java/com/example/mytodo/di/AppModule.kt
+++ b/app/src/main/java/com/example/mytodo/di/AppModule.kt
@@ -1,0 +1,23 @@
+package com.example.mytodo.di
+
+import androidx.room.Room
+import com.example.mytodo.MainViewModel
+import com.example.mytodo.model.todo.ToDoDatabase
+import com.example.mytodo.page.create.CreateToDoViewModel
+import com.example.mytodo.repository.todo.ToDoRepository
+import com.example.mytodo.repository.todo.ToDoRepositoryImpl
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+
+val appModule = module {
+    viewModel { CreateToDoViewModel(get()) }
+    single<ToDoRepository> { ToDoRepositoryImpl(get()) }
+    single {
+        Room.databaseBuilder(
+            get(),
+            ToDoDatabase::class.java,
+            "todo_database"
+        ).build()
+    }
+    single { get<ToDoDatabase>().todoDAO() }
+}

--- a/app/src/main/java/com/example/mytodo/page/create/CreateToDoFragment.kt
+++ b/app/src/main/java/com/example/mytodo/page/create/CreateToDoFragment.kt
@@ -12,9 +12,10 @@ import androidx.navigation.fragment.findNavController
 import com.example.mytodo.R
 import com.example.mytodo.databinding.CreateTodoFragmentBinding
 import com.google.android.material.snackbar.Snackbar
+import org.koin.android.ext.android.inject
 
 class CreateToDoFragment : Fragment(R.layout.create_todo_fragment) {
-    private val vm: CreateToDoViewModel by viewModels()
+    private val vm: CreateToDoViewModel by inject()
 
     private var _binding: CreateTodoFragmentBinding? = null
     private val binding: CreateTodoFragmentBinding get() = _binding!!

--- a/app/src/main/java/com/example/mytodo/page/create/CreateToDoViewModel.kt
+++ b/app/src/main/java/com/example/mytodo/page/create/CreateToDoViewModel.kt
@@ -4,12 +4,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.mytodo.repository.todo.ToDoRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class CreateToDoViewModel @Inject constructor(
+class CreateToDoViewModel(
     private val repo: ToDoRepository
 ): ViewModel() {
     val errorMessage = MutableLiveData<String>()

--- a/app/src/main/java/com/example/mytodo/page/detail/ToDoDetailFragment.kt
+++ b/app/src/main/java/com/example/mytodo/page/detail/ToDoDetailFragment.kt
@@ -3,7 +3,8 @@ package com.example.mytodo.page.detail
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.example.mytodo.R
+import org.koin.android.ext.android.inject
 
-class ToDoDetailFragment:Fragment(R.layout.todo_detail_fragment) {
-    private val vm: ToDoDetailViewModel by viewModels()
+class ToDoDetailFragment : Fragment(R.layout.todo_detail_fragment) {
+    private val vm: ToDoDetailViewModel by inject()
 }

--- a/app/src/main/java/com/example/mytodo/page/edit/EditToDoFragment.kt
+++ b/app/src/main/java/com/example/mytodo/page/edit/EditToDoFragment.kt
@@ -3,7 +3,8 @@ package com.example.mytodo.page.edit
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.example.mytodo.R
+import org.koin.android.ext.android.inject
 
-class EditToDoFragment:Fragment(R.layout.edit_todo_fragment) {
-    private val vm: EditToDoViewModel by viewModels()
+class EditToDoFragment : Fragment(R.layout.edit_todo_fragment) {
+    private val vm: EditToDoViewModel by inject()
 }


### PR DESCRIPTION
## 概要
DIライブラリをDaggerからKoinへ移行して、不足していたDIモジュール定義を追加します。

## 変更内容
- Daggerへの依存削除
- Koinの依存追加
- AppModuleの定義
- by viewModels()を by inject()に置換